### PR TITLE
use original filename if the user asks for it.

### DIFF
--- a/src/deark-dbuf.c
+++ b/src/deark-dbuf.c
@@ -1169,8 +1169,8 @@ dbuf *dbuf_create_output_file(deark *c, const char *ext1, de_finfo *fi,
 	{
 		de_strlcpy(nbuf, c->special_1st_filename, sizeof(nbuf));
 	}
-	else if(c->output_style==DE_OUTPUTSTYLE_ARCHIVE && !c->base_output_filename &&
-		fi && fi->original_filename_flag && name_from_finfo)
+	else if((c->output_style==DE_OUTPUTSTYLE_ARCHIVE || !c->filenames_from_file) && 
+	    !c->base_output_filename && fi && fi->original_filename_flag && name_from_finfo)
 	{
 		// TODO: This is a "temporary" hack to allow us to, when both reading from
 		// and writing to an archive format, use some semblance of the correct


### PR DESCRIPTION
I understand if you don't want to propagate the side effects of this hacky section but if the user asks for it (via `-nonames`) it would be cool if we would attempt to write the original filename to disk even if `c->output_style` is not `DE_OUTPUTSTYLE_ARCHIVE`