### PR TITLE
Support ':' as Amiga path separator

### DIFF
--- a/src/deark-config.h
+++ b/src/deark-config.h
@@ -11,12 +11,18 @@
 #endif
 #define DEARK_CONFIG_H_INC
 
-#if !defined(DE_WINDOWS) && !defined(DE_UNIX)
+#if !defined(DE_WINDOWS) && !defined(DE_UNIX) && !defined(DE_AMIGA)
 #ifdef _WIN32
 #define DE_WINDOWS
+#elif defined(__amigaos4__) || defined(AMIGA)
+#define DE_AMIGA
 #else
 #define DE_UNIX
 #endif
+#endif
+
+#ifdef DE_AMIGA
+#define DE_UNIX // Amiga uses the UNIX code in most instances
 #endif
 
 #ifdef DE_WINDOWS

--- a/src/deark-user.c
+++ b/src/deark-user.c
@@ -607,6 +607,9 @@ static int is_pathsep(i32 ch)
 #ifdef DE_WINDOWS
 	if(ch=='\\') return 1;
 #endif
+#ifdef DE_AMIGA
+	if(ch==':') return 1;
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
This PR allows Deark to support output paths which end in ':'.
AmigaOS uses this as a device/assign separator so without this patch it is not possible to specify the root of a device as the output path as Deark attempts to add a slash after it.

Without the patch:
```
1.> deark -od ram: angel.iff
Module: ilbm
Format: IFF-ILBM
Writing ram:/output.000.png
Error: Failed to write ram:/output.000.png: Invalid argument
```

With the patch:
```
1.> deark  -od ram: angel.iff
Module: ilbm
Format: IFF-ILBM
Writing ram:output.000.png
```
