### PR TITLE
deark-unix: fix build on macOS (st_mtim/st_atim do not exist)

### DIFF
--- a/src/deark-unix.c
+++ b/src/deark-unix.c
@@ -77,7 +77,16 @@ static int de_examine_file_by_fd(struct de_fopen_params *fop, int fd)
 
 	fop->len = (i64)stbuf.st_size;
 
-#if _POSIX_C_SOURCE >= 200809L
+#if defined(__APPLE__)
+	// On macOS, struct stat has no st_mtim/st_atim (nor st_mtimespec when
+	// _POSIX_C_SOURCE is defined); use st_mtime + st_mtimensec instead.
+	de_unix_time_to_timestamp(stbuf.st_mtime, &fop->orig_modtime, 0);
+	de_timestamp_set_subsec(&fop->orig_modtime,
+		(double)stbuf.st_mtimensec/1000000000.0);
+	de_unix_time_to_timestamp(stbuf.st_atime, &fop->orig_acctime, 0);
+	de_timestamp_set_subsec(&fop->orig_acctime,
+		(double)stbuf.st_atimensec/1000000000.0);
+#elif _POSIX_C_SOURCE >= 200809L
 	de_unix_time_to_timestamp(stbuf.st_mtim.tv_sec, &fop->orig_modtime, 0);
 	de_timestamp_set_subsec(&fop->orig_modtime,
 		(double)stbuf.st_mtim.tv_nsec/1000000000.0);


### PR DESCRIPTION
Since 1a95636 ("Added -tsopt option and related timestamp features"), de_examine_file_by_name() reads sub-second timestamps via stbuf.st_mtim and stbuf.st_atim under `#if _POSIX_C_SOURCE >= 200809L`.

deark-config.h defines _POSIX_C_SOURCE as 200809L, so this branch is taken on macOS too. But macOS <sys/stat.h> selects the timespec members based on _DARWIN_C_SOURCE:

    #if !defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE)
        struct timespec st_atimespec, st_mtimespec, ...;
    #else
        time_t st_atime; long st_atimensec;
        time_t st_mtime; long st_mtimensec; ...
    #endif

With _POSIX_C_SOURCE defined and _DARWIN_C_SOURCE undefined, struct stat has neither st_mtim nor st_mtimespec, only st_mtime + st_mtimensec, so the build fails:

    error: no member named 'st_mtim' in 'struct stat'

This affects every macOS version. Add an __APPLE__ branch that uses st_mtime/st_mtimensec (and st_atime/st_atimensec) to keep sub-second precision while building on macOS.

--- 

Or maybe there should be `deark-apple`? Not sure.
